### PR TITLE
fix: track online players and chunks bidirectionally

### DIFF
--- a/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
+++ b/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.plugin.PluginManager;
@@ -65,7 +66,7 @@ public class CloudWatch extends JavaPlugin {
         final PluginManager pluginManager = Bukkit.getPluginManager();
 
         pluginManager.registerEvents(chunkLoadListener.init(), this);
-        pluginManager.registerEvents(playerJoinListener, this);
+        pluginManager.registerEvents(playerJoinListener.init(), this);
 
         eventCountListeners.put("ChunksPopulated", new ChunkPopulateListener());
         eventCountListeners.put("CreaturesSpawned", new CreatureSpawnListener());
@@ -102,6 +103,7 @@ public class CloudWatch extends JavaPlugin {
         ChunkLoadEvent.getHandlerList().unregister(chunkLoadListener);
         ChunkUnloadEvent.getHandlerList().unregister(chunkLoadListener);
         PlayerJoinEvent.getHandlerList().unregister(playerJoinListener);
+        PlayerQuitEvent.getHandlerList().unregister(playerJoinListener);
 
         for (Map.Entry<String, EventCountListener> entry : eventCountListeners.entrySet()) {
             final Listener listener = entry.getValue();

--- a/src/main/java/github/metalshark/cloudwatch/listeners/ChunkLoadListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/ChunkLoadListener.java
@@ -15,7 +15,7 @@ public class ChunkLoadListener implements Listener {
 
     public ChunkLoadListener init() {
         for (World world : Bukkit.getWorlds()) {
-            count = world.getLoadedChunks().length;
+            count += world.getLoadedChunks().length;
         }
         return this;
     }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/PlayerJoinListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/PlayerJoinListener.java
@@ -1,26 +1,42 @@
 package github.metalshark.cloudwatch.listeners;
 
 import org.bukkit.Bukkit;
+import org.bukkit.World;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 public class PlayerJoinListener implements Listener {
 
-    private double maxOnlinePlayers = 0;
+    private double count = 0;
+    private double max = 0;
+
+    public PlayerJoinListener init() {
+        for (World world : Bukkit.getWorlds()) {
+            count += world.getPlayers().size();
+        }
+        return this;
+    }
 
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onPlayerJoin(PlayerJoinEvent event) {
-        final double onlinePlayers = Bukkit.getOnlinePlayers().size();
-        if (onlinePlayers > maxOnlinePlayers) maxOnlinePlayers = onlinePlayers;
+        count++;
+        if (count > max) max = count;
     }
 
-    public double getMaxOnlinePlayersAndReset() {
-        final double prevMaxOnlinePlayers = maxOnlinePlayers;
-        maxOnlinePlayers = 0;
-        return prevMaxOnlinePlayers;
+    @EventHandler(priority = EventPriority.MONITOR)
+    @SuppressWarnings("unused")
+    public void onPlayerLeave(PlayerQuitEvent event) {
+        count--;
+    }
+
+    public double getMaxAndReset() {
+        final double prevMax = max;
+        max = count;
+        return prevMax;
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/runnables/MinecraftStatisticsRunnable.java
+++ b/src/main/java/github/metalshark/cloudwatch/runnables/MinecraftStatisticsRunnable.java
@@ -19,7 +19,7 @@ public class MinecraftStatisticsRunnable implements Runnable {
         final double chunksLoaded = chunkLoadListener.getMaxAndReset();
 
         final PlayerJoinListener playerJoinListener = plugin.getPlayerJoinListener();
-        final double onlinePlayers = playerJoinListener.getMaxOnlinePlayersAndReset();
+        final double onlinePlayers = playerJoinListener.getMaxAndReset();
 
         final TickRunnable tickRunnable = plugin.getTickRunnable();
         final double maxTickTime = tickRunnable.getMaxElapsedMillisAndReset();


### PR DESCRIPTION
## Summary

Applies upstream fixes from [metalshark/CloudWatch@083c6b7](https://github.com/metalshark/CloudWatch/commit/083c6b756087343da39c3723a762017a6d2049ad) and [metalshark/CloudWatch@c3bbce3](https://github.com/metalshark/CloudWatch/commit/c3bbce3f1aca15a5087cca45a6e9ccf715acb213):

- **PlayerJoinListener**: Replaced snapshot-based sampling (`Bukkit.getOnlinePlayers().size()` on join) with bidirectional tracking — count increments on join, decrements on quit, and is initialized from current world state on plugin enable
- **ChunkLoadListener**: Fixed `init()` accumulation bug (`=` → `+=`) so chunk counts aggregate across all worlds instead of being overwritten per world
- **MinecraftStatisticsRunnable**: Updated method call `getMaxOnlinePlayersAndReset()` → `getMaxAndReset()`
- **CloudWatch**: Added `PlayerQuitEvent` import, `.init()` call on listener registration, and `PlayerQuitEvent` unregister in `onDisable`

## Test plan
- [ ] Start server with multiple worlds loaded — verify `ChunksLoaded` metric reflects sum across all worlds
- [ ] Join and quit players — verify `OnlinePlayers` metric tracks current count correctly
- [ ] Restart plugin (`/reload`) — verify listener re-registers and initializes counts cleanly