### PR TITLE
feat: add ECS/Fargate support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ mvn clean package
 # Output: target/CloudWatch-<version>.jar
 ```
 
-Java 14 source/target compatibility; CI uses JDK 17. No tests exist in this project.
+Java 17 source/target compatibility; CI uses JDK 17. No tests exist in this project.
 
 ## Architecture
 
@@ -32,7 +32,7 @@ If neither source is available the plugin disables itself.
 
 ### Listener pattern
 
-`EventCountListener` is the base class for all simple event counters. Subclasses register a single `@EventHandler` that increments `count`. Each minute `MinecraftStatisticsRunnable` calls `getCountAndReset()` on every entry in `CloudWatch.eventCountListeners` (a `ConcurrentHashMap<String, EventCountListener>`) and publishes one `MetricDatum` per entry.
+`EventCountListener` is the base class for all simple event counters. Subclasses register a single `@EventHandler` that increments an `AtomicLong count`. Each minute `MinecraftStatisticsRunnable` calls `getCountAndReset()` on every entry in `CloudWatch.eventCountListeners` (a `ConcurrentHashMap<String, EventCountListener>`) and publishes one `MetricDatum` per entry.
 
 Two listeners are **not** `EventCountListener` subclasses:
 - `ChunkLoadListener` — tracks current loaded-chunk count across load/unload events and exposes `getMaxAndReset()` (max chunks loaded during the period)
@@ -40,6 +40,6 @@ Two listeners are **not** `EventCountListener` subclasses:
 
 ### Deployment
 
-The Maven assembly plugin produces a fat JAR (`jar-with-dependencies`) that includes the AWS SDK v2 (`software.amazon.awssdk:cloudwatch`). This JAR is dropped into the Spigot `plugins/` directory. The IAM role must have `cloudwatch:PutMetricData` permission.
+The Maven assembly plugin produces a fat JAR (`jar-with-dependencies`) that includes the AWS SDK v2 (`software.amazon.awssdk:cloudwatch`). This JAR is dropped into the Spigot `plugins/` directory. The IAM role must have `cloudwatch:PutMetricData` permission. A single `CloudWatchClient` is created on enable and shared across both runnables; it is closed on disable.
 
 Releases are published to GitHub Packages via the `release.yml` workflow when a GitHub release is created.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+```bash
+# Build (produces fat JAR with all dependencies)
+mvn clean package
+
+# Output: target/CloudWatch-<version>.jar
+```
+
+Java 14 source/target compatibility; CI uses JDK 17. No tests exist in this project.
+
+## Architecture
+
+This is a Spigot (Bukkit) plugin that ships metrics to AWS CloudWatch every minute. On `onEnable()` it resolves a unique instance identifier to use as the CloudWatch `Dimension` value, trying two sources in order:
+
+1. EC2 IMDS via `EC2MetadataUtils.getInstanceId()`
+2. ECS/Fargate task metadata endpoint (`ECS_CONTAINER_METADATA_URI_V4` env var + `/task`) — extracts the task ID from the `TaskARN` field
+
+If neither source is available the plugin disables itself.
+
+### Three execution paths
+
+| Class | Thread | Schedule | CloudWatch namespace |
+|---|---|---|---|
+| `JavaStatisticsRunnable` | Dedicated `ScheduledExecutorService` | Every 1 minute | `Java` |
+| `MinecraftStatisticsRunnable` | Dedicated `ScheduledExecutorService` | Every 1 minute | `Minecraft` |
+| `TickRunnable` | Bukkit async scheduler | Every server tick (1/20s) | — (feeds into Minecraft runnable) |
+
+### Listener pattern
+
+`EventCountListener` is the base class for all simple event counters. Subclasses register a single `@EventHandler` that increments `count`. Each minute `MinecraftStatisticsRunnable` calls `getCountAndReset()` on every entry in `CloudWatch.eventCountListeners` (a `ConcurrentHashMap<String, EventCountListener>`) and publishes one `MetricDatum` per entry.
+
+Two listeners are **not** `EventCountListener` subclasses:
+- `ChunkLoadListener` — tracks current loaded-chunk count across load/unload events and exposes `getMaxAndReset()` (max chunks loaded during the period)
+- `PlayerJoinListener` — tracks peak online player count via join/quit events
+
+### Deployment
+
+The Maven assembly plugin produces a fat JAR (`jar-with-dependencies`) that includes the AWS SDK v2 (`software.amazon.awssdk:cloudwatch`). This JAR is dropped into the Spigot `plugins/` directory. The IAM role must have `cloudwatch:PutMetricData` permission.
+
+Releases are published to GitHub Packages via the `release.yml` workflow when a GitHub release is created.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@ mvn clean package
 # Output: target/CloudWatch-<version>.jar
 ```
 
-The plugin self-disables on startup if instance metadata is unreachable.
+The plugin self-disables on startup if instance metadata is unreachable. Requires Spigot 1.13+.
 
- ## Java Statistics
- All Java statistics collected are per minute and represent the current value or the count/total time during that period.
+## Metrics
+
+Metrics are published every minute to two CloudWatch namespaces, dimensioned by `Per-Instance Metrics = <EC2 instance ID or ECS task ID>`.
+
+## Java Statistics
+
+CloudWatch namespace: `Java`. All values represent the current value or the count/total time during that minute.
 
 - Number of Garbage Collections
 - Time spent performing Garbage Collection
@@ -33,8 +38,9 @@ The plugin self-disables on startup if instance metadata is unreachable.
 - Process CPU Load
 - System CPU Load
 
- ## Minecraft Statistics
- All Minecraft statistics collected are per minute and represent the maximum value, count or total time during that period.
+## Minecraft Statistics
+
+CloudWatch namespace: `Minecraft`. All values represent the maximum value, count, or total time during that minute.
 
 - Number of Online Players
 - Maximum Tick Time

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # CloudWatch
- [AWS CloudWatch](https://aws.amazon.com/cloudwatch/) monitoring plugin for Minecraft.
 
- No longer actively maintained. Please see https://github.com/MatthewDietrich/CloudWatch instead.
+[AWS CloudWatch](https://aws.amazon.com/cloudwatch/) monitoring plugin for Minecraft Spigot servers running on AWS.
 
- Requires the [Systems Manager](https://aws.amazon.com/systems-manager/) agent to have a role with the `cloudwatch:PutMetricData` [permission](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/permissions-reference-cw.html). This plugin is designed for Unix Operating Systems, such as Linux, and some statistics may not be recorded on other operating systems.
+Requires an IAM role with `cloudwatch:PutMetricData` [permission](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/permissions-reference-cw.html). Unix/Linux only — some statistics (file descriptors, CPU load) are unavailable on other operating systems.
+
+## Installation
+
+Build the fat JAR and drop it into your Spigot `plugins/` directory:
+
+```bash
+mvn clean package
+# Output: target/CloudWatch-<version>.jar
+```
+
+The plugin self-disables on startup if instance metadata is unreachable.
 
  ## Java Statistics
  All Java statistics collected are per minute and represent the current value or the count/total time during that period.

--- a/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
+++ b/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
@@ -20,6 +20,13 @@ import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 
+import org.yaml.snakeyaml.Yaml;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.*;
 
@@ -53,21 +60,50 @@ public class CloudWatch extends JavaPlugin {
     @Getter
     private CloudWatchClient cloudWatchClient;
 
+    private static String resolveInstanceId() {
+        try {
+            return EC2MetadataUtils.getInstanceId();
+        } catch (SdkClientException ignored) {}
+
+        final String metadataUri = System.getenv("ECS_CONTAINER_METADATA_URI_V4");
+        if (metadataUri == null) return null;
+
+        try {
+            final HttpClient client = HttpClient.newHttpClient();
+            final HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(metadataUri + "/task"))
+                .timeout(Duration.ofSeconds(2))
+                .build();
+            final String body = client.send(request, HttpResponse.BodyHandlers.ofString()).body();
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> metadata = new Yaml().load(body);
+            final String taskArn = (String) metadata.get("TaskARN");
+            if (taskArn == null) return null;
+            return taskArn.substring(taskArn.lastIndexOf('/') + 1);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
     @Override
     public void onEnable() {
         eventCountListeners.clear();
 
-        try {
-            dimension = Dimension
-                .builder()
-                .name("Per-Instance Metrics")
-                .value(EC2MetadataUtils.getInstanceId())
-                .build();
-        } catch (SdkClientException exception) {
-            getLogger().warning("The CloudWatch plugin only works on EC2 instances.");
+        final String instanceId = resolveInstanceId();
+        if (instanceId == null) {
+            getLogger().warning("The CloudWatch plugin requires EC2 or ECS/Fargate instance metadata.");
             this.setEnabled(false);
             return;
         }
+
+        dimension = Dimension
+            .builder()
+            .name("Per-Instance Metrics")
+            .value(instanceId)
+            .build();
 
         cloudWatchClient = CloudWatchClient.builder().build();
 


### PR DESCRIPTION
## Summary

- Adds fallback to ECS Task Metadata Endpoint v4 (`ECS_CONTAINER_METADATA_URI_V4`) when EC2 IMDS is unavailable, so the plugin works on Fargate as well as EC2
- Extracts the task ID from the `TaskARN` field and uses it as the CloudWatch dimension value
- Replaces hand-rolled regex JSON parsing with SnakeYAML (already an explicit dependency)
- Adds a 2s timeout to the ECS metadata HTTP request
- Makes `resolveInstanceId()` static
- Updates README and adds AGENTS.md

## Test plan

- [ ] Deploy to an ECS Fargate task and verify the plugin enables successfully and metrics appear in CloudWatch under the correct task ID dimension
- [ ] Verify EC2 deploy still works (EC2 IMDS path still tried first)
- [ ] Verify plugin self-disables with a clear warning when neither EC2 nor ECS metadata is available