### PR TITLE
Add unit tests and CI test step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,10 @@ jobs:
           java-version: '17'
           distribution: 'oracle'
           cache: 'maven'
+      - name: Run tests
+        run: mvn --batch-mode --update-snapshots test
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots package
+        run: mvn --batch-mode --update-snapshots -DskipTests package
       - name: Get version
         if: github.event_name == 'push' && github.ref == 'refs/heads/mainline'
         id: get_version

--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ mvn clean package
 
 The plugin self-disables on startup if instance metadata is unreachable. Requires Spigot 1.13+.
 
+## Development
+
+### Prerequisites
+
+- Java 17+
+- Maven 3.6+
+
+### Running Tests
+
+```bash
+mvn test
+```
+
+Tests cover the core metric-tracking components:
+
+- **TickRunnable** — tick counting and max elapsed time tracking
+- **EventCountListener** — atomic event counter with reset semantics
+- **ChunkLoadListener** — chunk load/unload tracking with high-water mark
+- **PlayerJoinListener** — player count tracking with high-water mark
+
 ## Metrics
 
 Metrics are published every minute to two CloudWatch namespaces, dimensioned by `Per-Instance Metrics = <EC2 instance ID or ECS task ID>`.

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
@@ -169,6 +174,20 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>2.6</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.18.0</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/src/test/java/github/metalshark/cloudwatch/listeners/ChunkLoadListenerTest.java
+++ b/src/test/java/github/metalshark/cloudwatch/listeners/ChunkLoadListenerTest.java
@@ -1,0 +1,99 @@
+package github.metalshark.cloudwatch.listeners;
+
+import org.bukkit.event.world.ChunkLoadEvent;
+import org.bukkit.event.world.ChunkUnloadEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ChunkLoadListenerTest {
+
+    private ChunkLoadListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new ChunkLoadListener();
+    }
+
+    @Test
+    void getMaxAndReset_returnsZeroInitially() {
+        assertEquals(0, listener.getMaxAndReset());
+    }
+
+    @Test
+    void onChunkLoad_incrementsCountAndUpdatesMax() {
+        ChunkLoadEvent event = mock(ChunkLoadEvent.class);
+
+        listener.onChunkLoad(event);
+        listener.onChunkLoad(event);
+        listener.onChunkLoad(event);
+
+        assertEquals(3, listener.getMaxAndReset());
+    }
+
+    @Test
+    void onChunkUnload_decrementsCount() {
+        ChunkLoadEvent loadEvent = mock(ChunkLoadEvent.class);
+        ChunkUnloadEvent unloadEvent = mock(ChunkUnloadEvent.class);
+
+        listener.onChunkLoad(loadEvent);
+        listener.onChunkLoad(loadEvent);
+        listener.onChunkLoad(loadEvent);
+        listener.onChunkUnload(unloadEvent);
+
+        // Max was 3 (before the unload), current count is 2
+        double max = listener.getMaxAndReset();
+        assertEquals(3, max);
+
+        // After reset, max should be current count (2)
+        assertEquals(2, listener.getMaxAndReset());
+    }
+
+    @Test
+    void getMaxAndReset_resetsMaxToCurrentCount() {
+        ChunkLoadEvent event = mock(ChunkLoadEvent.class);
+
+        listener.onChunkLoad(event);
+        listener.onChunkLoad(event);
+        listener.onChunkLoad(event);
+
+        // First read returns max of 3
+        assertEquals(3, listener.getMaxAndReset());
+
+        // After reset, max should be current count (still 3 since no unloads)
+        assertEquals(3, listener.getMaxAndReset());
+    }
+
+    @Test
+    void maxTracksHighWaterMark() {
+        ChunkLoadEvent loadEvent = mock(ChunkLoadEvent.class);
+        ChunkUnloadEvent unloadEvent = mock(ChunkUnloadEvent.class);
+
+        listener.onChunkLoad(loadEvent);
+        listener.onChunkLoad(loadEvent);
+        listener.onChunkLoad(loadEvent);  // count=3, max=3
+        listener.onChunkUnload(unloadEvent); // count=2, max still 3
+        listener.onChunkLoad(loadEvent);  // count=3, max=3
+        listener.onChunkUnload(unloadEvent); // count=2, max still 3
+
+        assertEquals(3, listener.getMaxAndReset());
+    }
+
+    @Test
+    void maxExceedsPreviousPeak() {
+        ChunkLoadEvent loadEvent = mock(ChunkLoadEvent.class);
+        ChunkUnloadEvent unloadEvent = mock(ChunkUnloadEvent.class);
+
+        listener.onChunkLoad(loadEvent);
+        listener.onChunkLoad(loadEvent);  // count=2, max=2
+
+        assertEquals(2, listener.getMaxAndReset()); // resets max to count=2
+
+        listener.onChunkLoad(loadEvent);
+        listener.onChunkLoad(loadEvent);  // count=4, max=4
+
+        assertEquals(4, listener.getMaxAndReset());
+    }
+}

--- a/src/test/java/github/metalshark/cloudwatch/listeners/EventCountListenerTest.java
+++ b/src/test/java/github/metalshark/cloudwatch/listeners/EventCountListenerTest.java
@@ -1,0 +1,68 @@
+package github.metalshark.cloudwatch.listeners;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EventCountListenerTest {
+
+    private EventCountListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new EventCountListener();
+    }
+
+    @Test
+    void getCountAndReset_returnsZeroInitially() {
+        assertEquals(0, listener.getCountAndReset());
+    }
+
+    @Test
+    void getCountAndReset_returnsAccumulatedCount() {
+        listener.count.incrementAndGet();
+        listener.count.incrementAndGet();
+        listener.count.incrementAndGet();
+
+        assertEquals(3, listener.getCountAndReset());
+    }
+
+    @Test
+    void getCountAndReset_resetsToZeroAfterRead() {
+        listener.count.incrementAndGet();
+        listener.count.incrementAndGet();
+
+        listener.getCountAndReset();
+        assertEquals(0, listener.getCountAndReset());
+    }
+
+    @Test
+    void getCountAndReset_handlesMultipleCycles() {
+        listener.count.addAndGet(5);
+        assertEquals(5, listener.getCountAndReset());
+
+        listener.count.addAndGet(3);
+        assertEquals(3, listener.getCountAndReset());
+
+        assertEquals(0, listener.getCountAndReset());
+    }
+
+    @Test
+    void count_isThreadSafe() throws InterruptedException {
+        final int iterations = 1000;
+        Thread t1 = new Thread(() -> {
+            for (int i = 0; i < iterations; i++) listener.count.incrementAndGet();
+        });
+        Thread t2 = new Thread(() -> {
+            for (int i = 0; i < iterations; i++) listener.count.incrementAndGet();
+        });
+
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+
+        assertEquals(iterations * 2, listener.getCountAndReset());
+    }
+}

--- a/src/test/java/github/metalshark/cloudwatch/listeners/PlayerJoinListenerTest.java
+++ b/src/test/java/github/metalshark/cloudwatch/listeners/PlayerJoinListenerTest.java
@@ -1,0 +1,82 @@
+package github.metalshark.cloudwatch.listeners;
+
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PlayerJoinListenerTest {
+
+    private PlayerJoinListener listener;
+
+    @BeforeEach
+    void setUp() {
+        listener = new PlayerJoinListener();
+    }
+
+    @Test
+    void getMaxAndReset_returnsZeroInitially() {
+        assertEquals(0, listener.getMaxAndReset());
+    }
+
+    @Test
+    void onPlayerJoin_incrementsCountAndUpdatesMax() {
+        PlayerJoinEvent event = mock(PlayerJoinEvent.class);
+
+        listener.onPlayerJoin(event);
+        listener.onPlayerJoin(event);
+
+        assertEquals(2, listener.getMaxAndReset());
+    }
+
+    @Test
+    void onPlayerLeave_decrementsCount() {
+        PlayerJoinEvent joinEvent = mock(PlayerJoinEvent.class);
+        PlayerQuitEvent quitEvent = mock(PlayerQuitEvent.class);
+
+        listener.onPlayerJoin(joinEvent);
+        listener.onPlayerJoin(joinEvent);
+        listener.onPlayerJoin(joinEvent);
+        listener.onPlayerLeave(quitEvent);
+
+        // Max was 3, current count is 2
+        assertEquals(3, listener.getMaxAndReset());
+        // After reset, max tracks current count
+        assertEquals(2, listener.getMaxAndReset());
+    }
+
+    @Test
+    void maxTracksHighWaterMark() {
+        PlayerJoinEvent joinEvent = mock(PlayerJoinEvent.class);
+        PlayerQuitEvent quitEvent = mock(PlayerQuitEvent.class);
+
+        listener.onPlayerJoin(joinEvent);
+        listener.onPlayerJoin(joinEvent);
+        listener.onPlayerJoin(joinEvent);   // count=3, max=3
+        listener.onPlayerLeave(quitEvent);  // count=2
+        listener.onPlayerLeave(quitEvent);  // count=1
+
+        assertEquals(3, listener.getMaxAndReset());
+    }
+
+    @Test
+    void multipleCyclesTrackIndependently() {
+        PlayerJoinEvent joinEvent = mock(PlayerJoinEvent.class);
+        PlayerQuitEvent quitEvent = mock(PlayerQuitEvent.class);
+
+        // Cycle 1: 2 players peak
+        listener.onPlayerJoin(joinEvent);
+        listener.onPlayerJoin(joinEvent);
+        assertEquals(2, listener.getMaxAndReset());
+
+        // Cycle 2: 1 leaves, 2 join -> peak is 3
+        listener.onPlayerLeave(quitEvent);   // count=1
+        listener.onPlayerJoin(joinEvent);     // count=2
+        listener.onPlayerJoin(joinEvent);     // count=3
+
+        assertEquals(3, listener.getMaxAndReset());
+    }
+}

--- a/src/test/java/github/metalshark/cloudwatch/runnables/TickRunnableTest.java
+++ b/src/test/java/github/metalshark/cloudwatch/runnables/TickRunnableTest.java
@@ -1,0 +1,90 @@
+package github.metalshark.cloudwatch.runnables;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TickRunnableTest {
+
+    private TickRunnable tickRunnable;
+
+    @BeforeEach
+    void setUp() {
+        tickRunnable = new TickRunnable();
+    }
+
+    @Test
+    void getNumberOfTicksAndReset_returnsZeroInitially() {
+        assertEquals(0, tickRunnable.getNumberOfTicksAndReset());
+    }
+
+    @Test
+    void run_incrementsTickCount() {
+        tickRunnable.run();
+        tickRunnable.run();
+        tickRunnable.run();
+
+        assertEquals(3, tickRunnable.getNumberOfTicksAndReset());
+    }
+
+    @Test
+    void getNumberOfTicksAndReset_resetsAfterRead() {
+        tickRunnable.run();
+        tickRunnable.run();
+
+        tickRunnable.getNumberOfTicksAndReset();
+        assertEquals(0, tickRunnable.getNumberOfTicksAndReset());
+    }
+
+    @Test
+    void getMaxElapsedMillisAndReset_returnsZeroInitially() {
+        assertEquals(0, tickRunnable.getMaxElapsedMillisAndReset());
+    }
+
+    @Test
+    void getMaxElapsedMillisAndReset_resetsAfterRead() throws InterruptedException {
+        tickRunnable.run();
+        Thread.sleep(50);
+        tickRunnable.run();
+
+        double max = tickRunnable.getMaxElapsedMillisAndReset();
+        assertTrue(max >= 40, "Max elapsed should be at least 40ms, was: " + max);
+
+        assertEquals(0, tickRunnable.getMaxElapsedMillisAndReset());
+    }
+
+    @Test
+    void run_tracksMaxElapsedTime() throws InterruptedException {
+        tickRunnable.run();
+        Thread.sleep(20);
+        tickRunnable.run();
+        Thread.sleep(60);
+        tickRunnable.run();
+
+        double max = tickRunnable.getMaxElapsedMillisAndReset();
+        assertTrue(max >= 50, "Max elapsed should reflect the longest tick gap, was: " + max);
+    }
+
+    @Test
+    void run_multipleCyclesAreIndependent() throws InterruptedException {
+        // First cycle
+        tickRunnable.run();
+        Thread.sleep(30);
+        tickRunnable.run();
+        double firstMax = tickRunnable.getMaxElapsedMillisAndReset();
+        double firstTicks = tickRunnable.getNumberOfTicksAndReset();
+
+        assertTrue(firstMax >= 20);
+        assertEquals(2, firstTicks);
+
+        // Second cycle
+        tickRunnable.run();
+        double secondMax = tickRunnable.getMaxElapsedMillisAndReset();
+        double secondTicks = tickRunnable.getNumberOfTicksAndReset();
+
+        assertEquals(1, secondTicks);
+        // Second max should be small since no sleep between reset and run
+        assertTrue(secondMax < firstMax || secondMax >= 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Add JUnit 5 and Mockito test dependencies with maven-surefire-plugin
- Add unit tests for `TickRunnable`, `EventCountListener`, `ChunkLoadListener`, and `PlayerJoinListener` (20 tests)
- Add explicit "Run tests" step to CI workflow before the build
- Document testing prerequisites and instructions in README

## Test plan
- [ ] Verify CI workflow runs tests successfully
- [ ] Confirm build step still produces the fat JAR