### PR TITLE
fix: security hardening and performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,26 @@ mvn clean package
 # Output: target/CloudWatch-<version>.jar
 ```
 
-The plugin self-disables on startup if instance metadata is unreachable. Requires Spigot 1.13+.
+Requires Spigot 1.13+.
+
+## Configuration
+
+The plugin needs a server name to use as the CloudWatch dimension value. It resolves the name in this order:
+
+1. `SPIGOT_CLOUDWATCH_SERVER` environment variable
+2. `server` key in `plugins/CloudWatch/config.yml`
+3. EC2 instance ID (via EC2 instance metadata service)
+4. ECS task ID (via `ECS_CONTAINER_METADATA_URI_V4` metadata endpoint)
+
+The plugin self-disables on startup if no server identity can be determined from any of these sources.
+
+**config.yml** (auto-generated on first run):
+
+```yaml
+server: ""
+```
+
+Set `server` to a stable name for your instance if you are not running on EC2 or ECS, or want to override the auto-detected value.
 
 ## Development
 
@@ -37,7 +56,7 @@ Tests cover the core metric-tracking components:
 
 ## Metrics
 
-Metrics are published every minute to two CloudWatch namespaces, dimensioned by `Per-Instance Metrics = <EC2 instance ID or ECS task ID>`.
+Metrics are published every minute to two CloudWatch namespaces, dimensioned by `Server = <server name>`.
 
 ## Java Statistics
 

--- a/pom.xml
+++ b/pom.xml
@@ -178,9 +178,9 @@
             <version>1.21.0</version>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>2.6</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.2</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
+++ b/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
@@ -1,5 +1,7 @@
 package github.metalshark.cloudwatch;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import github.metalshark.cloudwatch.listeners.*;
 import github.metalshark.cloudwatch.runnables.JavaStatisticsRunnable;
@@ -19,8 +21,6 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.internal.util.EC2MetadataUtils;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
-
-import org.yaml.snakeyaml.Yaml;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -51,11 +51,13 @@ public class CloudWatch extends JavaPlugin {
         .setNameFormat("CloudWatch - Minecraft Statistics")
         .build();
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private ScheduledExecutorService javaStatisticsExecutor;
     private ScheduledExecutorService minecraftStatisticsExecutor;
 
     @Getter
-    private static Dimension dimension;
+    private Dimension dimension;
 
     @Getter
     private CloudWatchClient cloudWatchClient;
@@ -68,41 +70,63 @@ public class CloudWatch extends JavaPlugin {
         final String metadataUri = System.getenv("ECS_CONTAINER_METADATA_URI_V4");
         if (metadataUri == null) return null;
 
+        // Prevent SSRF: only allow the ECS task metadata endpoint
         try {
-            final HttpClient client = HttpClient.newHttpClient();
+            final URI uri = URI.create(metadataUri);
+            if (!"http".equals(uri.getScheme()) || !"169.254.170.2".equals(uri.getHost())) {
+                return null;
+            }
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+
+        final ExecutorService httpExecutor = Executors.newSingleThreadExecutor();
+        try {
+            final HttpClient client = HttpClient.newBuilder().executor(httpExecutor).build();
             final HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(metadataUri + "/task"))
                 .timeout(Duration.ofSeconds(2))
                 .build();
             final String body = client.send(request, HttpResponse.BodyHandlers.ofString()).body();
-            @SuppressWarnings("unchecked")
-            final Map<String, Object> metadata = new Yaml().load(body);
-            final String taskArn = (String) metadata.get("TaskARN");
-            if (taskArn == null) return null;
+            final JsonNode metadata = OBJECT_MAPPER.readTree(body);
+            final JsonNode taskArnNode = metadata.get("TaskARN");
+            if (taskArnNode == null || taskArnNode.isNull()) return null;
+            final String taskArn = taskArnNode.asText();
             return taskArn.substring(taskArn.lastIndexOf('/') + 1);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             return null;
         } catch (Exception ignored) {
             return null;
+        } finally {
+            httpExecutor.shutdownNow();
         }
+    }
+
+    private String resolveServer() {
+        String s = System.getenv("SPIGOT_CLOUDWATCH_SERVER");
+        if (s != null && !s.isBlank()) return s.trim();
+        s = getConfig().getString("server", "");
+        return s != null ? s.trim() : "";
     }
 
     @Override
     public void onEnable() {
         eventCountListeners.clear();
 
-        saveDefaultConfig();  // loads config.yml defaults before getConfig() is readable
+        saveDefaultConfig();
 
-        String server = System.getenv("SPIGOT_CLOUDWATCH_SERVER");
-        if (server == null || server.isEmpty()) {
-            server = getConfig().getString("server", "");
-        }
-        if (server == null || server.isEmpty()) {
+        String server = resolveServer();
+        if (server.isEmpty()) {
             server = resolveInstanceId();
         }
         if (server == null || server.isEmpty()) {
             getLogger().warning("Could not determine server identity. Disabling CloudWatch plugin.");
+            this.setEnabled(false);
+            return;
+        }
+        if (server.length() > 256 || !server.chars().allMatch(c -> c >= 0x20 && c <= 0x7E)) {
+            getLogger().warning("Server identity is invalid (must be 1-256 printable ASCII characters). Disabling CloudWatch plugin.");
             this.setEnabled(false);
             return;
         }
@@ -142,10 +166,12 @@ public class CloudWatch extends JavaPlugin {
         }
 
         javaStatisticsExecutor = Executors.newSingleThreadScheduledExecutor(javaStatisticsThreadFactory);
-        javaStatisticsExecutor.scheduleAtFixedRate(new JavaStatisticsRunnable(), 0, 1, TimeUnit.MINUTES);
+        javaStatisticsExecutor.scheduleAtFixedRate(
+            new JavaStatisticsRunnable(dimension, cloudWatchClient), 0, 1, TimeUnit.MINUTES);
 
         minecraftStatisticsExecutor = Executors.newSingleThreadScheduledExecutor(minecraftStatisticsThreadFactory);
-        minecraftStatisticsExecutor.scheduleAtFixedRate(new MinecraftStatisticsRunnable(), 0, 1, TimeUnit.MINUTES);
+        minecraftStatisticsExecutor.scheduleAtFixedRate(
+            new MinecraftStatisticsRunnable(this, dimension, cloudWatchClient), 0, 1, TimeUnit.MINUTES);
 
         Bukkit.getServer().getScheduler().runTaskTimerAsynchronously(this, tickRunnable, 1, 1);
     }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/ChunkPopulateListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/ChunkPopulateListener.java
@@ -9,7 +9,7 @@ public class ChunkPopulateListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(ChunkPopulateEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/CreatureSpawnListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/CreatureSpawnListener.java
@@ -9,7 +9,7 @@ public class CreatureSpawnListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(CreatureSpawnEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/EntityDeathListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/EntityDeathListener.java
@@ -9,7 +9,7 @@ public class EntityDeathListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(EntityDeathEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/EventCountListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/EventCountListener.java
@@ -6,7 +6,11 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class EventCountListener implements Listener {
 
-    protected final AtomicLong count = new AtomicLong(0);
+    private final AtomicLong count = new AtomicLong(0);
+
+    protected void increment() {
+        count.incrementAndGet();
+    }
 
     public double getCountAndReset() {
         return count.getAndSet(0);

--- a/src/main/java/github/metalshark/cloudwatch/listeners/InventoryClickListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/InventoryClickListener.java
@@ -9,7 +9,7 @@ public class InventoryClickListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(InventoryClickEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/InventoryCloseListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/InventoryCloseListener.java
@@ -9,7 +9,7 @@ public class InventoryCloseListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(InventoryCloseEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/InventoryDragListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/InventoryDragListener.java
@@ -9,7 +9,7 @@ public class InventoryDragListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(InventoryDragEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/InventoryOpenListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/InventoryOpenListener.java
@@ -9,7 +9,7 @@ public class InventoryOpenListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(InventoryOpenEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/ItemDespawnListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/ItemDespawnListener.java
@@ -9,7 +9,7 @@ public class ItemDespawnListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(ItemDespawnEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/ItemSpawnListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/ItemSpawnListener.java
@@ -9,7 +9,7 @@ public class ItemSpawnListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(ItemSpawnEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/PlayerDropItemListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/PlayerDropItemListener.java
@@ -9,7 +9,7 @@ public class PlayerDropItemListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(PlayerDropItemEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/PlayerExpChangeListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/PlayerExpChangeListener.java
@@ -9,7 +9,7 @@ public class PlayerExpChangeListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(PlayerExpChangeEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/PlayerInteractListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/PlayerInteractListener.java
@@ -9,7 +9,7 @@ public class PlayerInteractListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(PlayerInteractEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/ProjectileLaunchListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/ProjectileLaunchListener.java
@@ -9,7 +9,7 @@ public class ProjectileLaunchListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(ProjectileLaunchEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/StructureGrowListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/StructureGrowListener.java
@@ -9,7 +9,7 @@ public class StructureGrowListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(StructureGrowEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/listeners/TradeSelectListener.java
+++ b/src/main/java/github/metalshark/cloudwatch/listeners/TradeSelectListener.java
@@ -9,7 +9,7 @@ public class TradeSelectListener extends EventCountListener {
     @EventHandler(priority=EventPriority.MONITOR)
     @SuppressWarnings("unused")
     public void onEvent(TradeSelectEvent event) {
-        count.incrementAndGet();
+        increment();
     }
 
 }

--- a/src/main/java/github/metalshark/cloudwatch/runnables/JavaStatisticsRunnable.java
+++ b/src/main/java/github/metalshark/cloudwatch/runnables/JavaStatisticsRunnable.java
@@ -5,33 +5,39 @@ import github.metalshark.cloudwatch.CloudWatch;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.*;
 
-import java.lang.management.GarbageCollectorMXBean;
-import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.*;
+import java.util.List;
 
 public class JavaStatisticsRunnable implements Runnable {
+
+    private final Dimension dimension;
+    private final CloudWatchClient cloudWatchClient;
+
+    private final List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();
+    private final ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+    private final MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+    private final OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
 
     private double prevTotalGarbageCollections = 0;
     private double prevTotalGarbageCollectionTime = 0;
     private boolean firstRun = true;
+
+    public JavaStatisticsRunnable(Dimension dimension, CloudWatchClient cloudWatchClient) {
+        this.dimension = dimension;
+        this.cloudWatchClient = cloudWatchClient;
+    }
 
     public void run() {
 
         double totalGarbageCollections = 0;
         double totalGarbageCollectionTime = 0;
 
-        for(GarbageCollectorMXBean gc : ManagementFactory.getGarbageCollectorMXBeans()) {
+        for (GarbageCollectorMXBean gc : gcBeans) {
             final long count = gc.getCollectionCount();
-
-            if (count >= 0) {
-                totalGarbageCollections += count;
-            }
+            if (count >= 0) totalGarbageCollections += count;
 
             final long time = gc.getCollectionTime();
-
-            if (time >= 0) {
-                totalGarbageCollectionTime += time;
-            }
+            if (time >= 0) totalGarbageCollectionTime += time;
         }
 
         final double garbageCollections = totalGarbageCollections - prevTotalGarbageCollections;
@@ -45,15 +51,15 @@ public class JavaStatisticsRunnable implements Runnable {
             return;
         }
 
-        // Get current size of heap in bytes
-        final double heapSize = Runtime.getRuntime().totalMemory();
-        // Get maximum size of heap in bytes. The heap cannot grow beyond this size.// Any attempt will result in an OutOfMemoryException.
-        final double heapMaxSize = Runtime.getRuntime().maxMemory();
-        // Get amount of free memory within the heap in bytes. This size will increase // after garbage collection and decrease as new objects are created.
-        final double heapFreeSize = Runtime.getRuntime().freeMemory();
-        final double heapUsedSize = heapSize - heapFreeSize;
+        // MemoryMXBean.getHeapMemoryUsage() returns a consistent snapshot, avoiding
+        // the race between separate Runtime.totalMemory()/freeMemory() calls.
+        final MemoryUsage heap = memoryBean.getHeapMemoryUsage();
+        final double heapSize = heap.getCommitted();
+        final double heapMaxSize = heap.getMax();
+        final double heapUsedSize = heap.getUsed();
+        final double heapFreeSize = heapSize - heapUsedSize;
 
-        final double threadCount = ManagementFactory.getThreadMXBean().getThreadCount();
+        final double threadCount = threadBean.getThreadCount();
 
         double openFileDescriptors = 0;
         double maxFileDescriptors = 0;
@@ -62,9 +68,8 @@ public class JavaStatisticsRunnable implements Runnable {
         double usedPhysicalMemorySize = 0;
         double processCpuLoad = 0;
         double systemCpuLoad = 0;
-        final OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
-        if (os instanceof UnixOperatingSystemMXBean) {
-            final UnixOperatingSystemMXBean unixOs = (UnixOperatingSystemMXBean) os;
+        if (osBean instanceof UnixOperatingSystemMXBean) {
+            final UnixOperatingSystemMXBean unixOs = (UnixOperatingSystemMXBean) osBean;
             openFileDescriptors = unixOs.getOpenFileDescriptorCount();
             maxFileDescriptors = unixOs.getMaxFileDescriptorCount();
             totalPhysicalMemorySize = unixOs.getTotalMemorySize();
@@ -74,135 +79,28 @@ public class JavaStatisticsRunnable implements Runnable {
             systemCpuLoad = unixOs.getCpuLoad() * 100;
         }
 
-        final Dimension dimension = CloudWatch.getDimension();
-
-        final CloudWatchClient cw = CloudWatch.getPlugin().getCloudWatchClient();
         try {
-            final MetricDatum garbageCollectionsMetric = MetricDatum
-                .builder()
-                .metricName("GarbageCollections")
-                .unit(StandardUnit.COUNT)
-                .value(garbageCollections)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum garbageCollectionTimeMetric = MetricDatum
-                .builder()
-                .metricName("GarbageCollectionTime")
-                .unit(StandardUnit.MILLISECONDS)
-                .value(garbageCollectionTime)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum heapSizeMetric = MetricDatum
-                .builder()
-                .metricName("HeapSize")
-                .unit(StandardUnit.BYTES)
-                .value(heapSize)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum heapMaxSizeMetric = MetricDatum
-                .builder()
-                .metricName("HeapMaxSize")
-                .unit(StandardUnit.BYTES)
-                .value(heapMaxSize)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum heapFreeSizeMetric = MetricDatum
-                .builder()
-                .metricName("HeapFreeSize")
-                .unit(StandardUnit.BYTES)
-                .value(heapFreeSize)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum heapUsedSizeMetric = MetricDatum
-                .builder()
-                .metricName("HeapUsedSize")
-                .unit(StandardUnit.BYTES)
-                .value(heapUsedSize)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum threadCountMetric = MetricDatum
-                .builder()
-                .metricName("Threads")
-                .unit(StandardUnit.COUNT)
-                .value(threadCount)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum openFileDescriptorsMetric = MetricDatum
-                .builder()
-                .metricName("OpenFileDescriptors")
-                .unit(StandardUnit.COUNT)
-                .value(openFileDescriptors)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum maxFileDescriptorsMetric = MetricDatum
-                .builder()
-                .metricName("MaxFileDescriptors")
-                .unit(StandardUnit.COUNT)
-                .value(maxFileDescriptors)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum totalPhysicalMemorySizeMetric = MetricDatum
-                .builder()
-                .metricName("TotalPhysicalMemorySize")
-                .unit(StandardUnit.BYTES)
-                .value(totalPhysicalMemorySize)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum freePhysicalMemorySizeMetric = MetricDatum
-                .builder()
-                .metricName("FreePhysicalMemorySize")
-                .unit(StandardUnit.BYTES)
-                .value(freePhysicalMemorySize)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum usedPhysicalMemorySizeMetric = MetricDatum
-                .builder()
-                .metricName("UsedPhysicalMemorySize")
-                .unit(StandardUnit.BYTES)
-                .value(usedPhysicalMemorySize)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum processCpuLoadMetric = MetricDatum
-                .builder()
-                .metricName("ProcessCpuLoad")
-                .unit(StandardUnit.PERCENT)
-                .value(processCpuLoad)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum systemCpuLoadMetric = MetricDatum
-                .builder()
-                .metricName("SystemCpuLoad")
-                .unit(StandardUnit.PERCENT)
-                .value(systemCpuLoad)
-                .dimensions(dimension)
-                .build();
-
-            final MetricDatum[] metrics = new MetricDatum[]{
-                garbageCollectionsMetric,
-                garbageCollectionTimeMetric,
-                heapSizeMetric,
-                heapMaxSizeMetric,
-                heapFreeSizeMetric,
-                heapUsedSizeMetric,
-                threadCountMetric,
-                openFileDescriptorsMetric,
-                maxFileDescriptorsMetric,
-                totalPhysicalMemorySizeMetric,
-                freePhysicalMemorySizeMetric,
-                usedPhysicalMemorySizeMetric,
-                processCpuLoadMetric,
-                systemCpuLoadMetric
-            };
-
-            final PutMetricDataRequest request = PutMetricDataRequest
-                .builder()
+            cloudWatchClient.putMetricData(PutMetricDataRequest.builder()
                 .namespace("Java")
-                .metricData(metrics)
-                .build();
-
-            cw.putMetricData(request);
+                .metricData(List.of(
+                    MetricDatum.builder().metricName("GarbageCollections").unit(StandardUnit.COUNT).value(garbageCollections).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("GarbageCollectionTime").unit(StandardUnit.MILLISECONDS).value(garbageCollectionTime).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("HeapSize").unit(StandardUnit.BYTES).value(heapSize).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("HeapMaxSize").unit(StandardUnit.BYTES).value(heapMaxSize).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("HeapFreeSize").unit(StandardUnit.BYTES).value(heapFreeSize).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("HeapUsedSize").unit(StandardUnit.BYTES).value(heapUsedSize).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("Threads").unit(StandardUnit.COUNT).value(threadCount).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("OpenFileDescriptors").unit(StandardUnit.COUNT).value(openFileDescriptors).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("MaxFileDescriptors").unit(StandardUnit.COUNT).value(maxFileDescriptors).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("TotalPhysicalMemorySize").unit(StandardUnit.BYTES).value(totalPhysicalMemorySize).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("FreePhysicalMemorySize").unit(StandardUnit.BYTES).value(freePhysicalMemorySize).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("UsedPhysicalMemorySize").unit(StandardUnit.BYTES).value(usedPhysicalMemorySize).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("ProcessCpuLoad").unit(StandardUnit.PERCENT).value(processCpuLoad).dimensions(dimension).build(),
+                    MetricDatum.builder().metricName("SystemCpuLoad").unit(StandardUnit.PERCENT).value(systemCpuLoad).dimensions(dimension).build()
+                ))
+                .build());
         } catch (CloudWatchException e) {
-            CloudWatch.getPlugin().getLogger().severe(e.awsErrorDetails().errorMessage());
+            CloudWatch.getPlugin().getLogger().warning("CloudWatch PutMetricData failed [Java]: " + e.awsErrorDetails().errorCode());
         }
     }
 

--- a/src/main/java/github/metalshark/cloudwatch/runnables/MinecraftStatisticsRunnable.java
+++ b/src/main/java/github/metalshark/cloudwatch/runnables/MinecraftStatisticsRunnable.java
@@ -1,7 +1,6 @@
 package github.metalshark.cloudwatch.runnables;
 
 import github.metalshark.cloudwatch.CloudWatch;
-import github.metalshark.cloudwatch.listeners.*;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.*;
 
@@ -10,82 +9,44 @@ import java.util.List;
 
 public class MinecraftStatisticsRunnable implements Runnable {
 
+    private final CloudWatch plugin;
+    private final Dimension dimension;
+    private final CloudWatchClient cloudWatchClient;
+
+    public MinecraftStatisticsRunnable(CloudWatch plugin, Dimension dimension, CloudWatchClient cloudWatchClient) {
+        this.plugin = plugin;
+        this.dimension = dimension;
+        this.cloudWatchClient = cloudWatchClient;
+    }
+
     @Override
     public void run() {
-        final CloudWatch plugin = CloudWatch.getPlugin();
-        final Dimension dimension = CloudWatch.getDimension();
-
-        final ChunkLoadListener chunkLoadListener = plugin.getChunkLoadListener();
-        final double chunksLoaded = chunkLoadListener.getMaxAndReset();
-
-        final PlayerJoinListener playerJoinListener = plugin.getPlayerJoinListener();
-        final double onlinePlayers = playerJoinListener.getMaxAndReset();
+        final double chunksLoaded = plugin.getChunkLoadListener().getMaxAndReset();
+        final double onlinePlayers = plugin.getPlayerJoinListener().getMaxAndReset();
 
         final TickRunnable tickRunnable = plugin.getTickRunnable();
         final double maxTickTime = tickRunnable.getMaxElapsedMillisAndReset();
-        final double ticksPerMinute = tickRunnable.getNumberOfTicksAndReset();
-        final double ticksPerSecond = ticksPerMinute / 60;
+        final double ticksPerSecond = tickRunnable.getNumberOfTicksAndReset() / 60.0;
 
-        final CloudWatchClient cw = CloudWatch.getPlugin().getCloudWatchClient();
         try {
+            final List<MetricDatum> metrics = new ArrayList<>(4 + CloudWatch.getEventCountListeners().size());
+            metrics.add(MetricDatum.builder().metricName("ChunksLoaded").unit(StandardUnit.COUNT).value(chunksLoaded).dimensions(dimension).build());
+            metrics.add(MetricDatum.builder().metricName("OnlinePlayers").unit(StandardUnit.COUNT).value(onlinePlayers).dimensions(dimension).build());
+            metrics.add(MetricDatum.builder().metricName("MaxTickTime").unit(StandardUnit.MILLISECONDS).value(maxTickTime).dimensions(dimension).build());
+            metrics.add(MetricDatum.builder().metricName("TicksPerSecond").unit(StandardUnit.COUNT).value(ticksPerSecond).dimensions(dimension).build());
 
-            final MetricDatum chunksLoadedMetric = MetricDatum
-                .builder()
-                .metricName("ChunksLoaded")
-                .unit(StandardUnit.COUNT)
-                .value(chunksLoaded)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum onlinePlayersMetric = MetricDatum
-                .builder()
-                .metricName("OnlinePlayers")
-                .unit(StandardUnit.COUNT)
-                .value(onlinePlayers)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum maxTickTimeMetric = MetricDatum
-                .builder()
-                .metricName("MaxTickTime")
-                .unit(StandardUnit.MILLISECONDS)
-                .value(maxTickTime)
-                .dimensions(dimension)
-                .build();
-            final MetricDatum ticksPerSecondMetric = MetricDatum
-                .builder()
-                .metricName("TicksPerSecond")
-                .unit(StandardUnit.COUNT)
-                .value(ticksPerSecond)
-                .dimensions(dimension)
-                .build();
+            CloudWatch.getEventCountListeners().forEach((name, listener) ->
+                metrics.add(MetricDatum.builder()
+                    .metricName(name)
+                    .unit(StandardUnit.COUNT)
+                    .value(listener.getCountAndReset())
+                    .dimensions(dimension)
+                    .build()));
 
-            final List<MetricDatum> metricDatumList = new ArrayList<>();
-            metricDatumList.add(chunksLoadedMetric);
-            metricDatumList.add(maxTickTimeMetric);
-            metricDatumList.add(onlinePlayersMetric);
-            metricDatumList.add(ticksPerSecondMetric);
-
-            CloudWatch
-                .getEventCountListeners()
-                .forEach((name, listener) -> {
-                    final double count = listener.getCountAndReset();
-                    metricDatumList.add(MetricDatum
-                        .builder()
-                        .metricName(name)
-                        .unit(StandardUnit.COUNT)
-                        .value(count)
-                        .dimensions(dimension)
-                        .build());
-                });
-
-            final PutMetricDataRequest request = PutMetricDataRequest
-                .builder()
-                .namespace("Minecraft")
-                .metricData(metricDatumList)
-                .build();
-
-            cw.putMetricData(request);
+            cloudWatchClient.putMetricData(
+                PutMetricDataRequest.builder().namespace("Minecraft").metricData(metrics).build());
         } catch (CloudWatchException e) {
-            CloudWatch.getPlugin().getLogger().severe(e.awsErrorDetails().errorMessage());
+            plugin.getLogger().warning("CloudWatch PutMetricData failed [Minecraft]: " + e.awsErrorDetails().errorCode());
         }
     }
 

--- a/src/test/java/github/metalshark/cloudwatch/listeners/EventCountListenerTest.java
+++ b/src/test/java/github/metalshark/cloudwatch/listeners/EventCountListenerTest.java
@@ -21,17 +21,17 @@ class EventCountListenerTest {
 
     @Test
     void getCountAndReset_returnsAccumulatedCount() {
-        listener.count.incrementAndGet();
-        listener.count.incrementAndGet();
-        listener.count.incrementAndGet();
+        listener.increment();
+        listener.increment();
+        listener.increment();
 
         assertEquals(3, listener.getCountAndReset());
     }
 
     @Test
     void getCountAndReset_resetsToZeroAfterRead() {
-        listener.count.incrementAndGet();
-        listener.count.incrementAndGet();
+        listener.increment();
+        listener.increment();
 
         listener.getCountAndReset();
         assertEquals(0, listener.getCountAndReset());
@@ -39,23 +39,23 @@ class EventCountListenerTest {
 
     @Test
     void getCountAndReset_handlesMultipleCycles() {
-        listener.count.addAndGet(5);
+        for (int i = 0; i < 5; i++) listener.increment();
         assertEquals(5, listener.getCountAndReset());
 
-        listener.count.addAndGet(3);
+        for (int i = 0; i < 3; i++) listener.increment();
         assertEquals(3, listener.getCountAndReset());
 
         assertEquals(0, listener.getCountAndReset());
     }
 
     @Test
-    void count_isThreadSafe() throws InterruptedException {
+    void increment_isThreadSafe() throws InterruptedException {
         final int iterations = 1000;
         Thread t1 = new Thread(() -> {
-            for (int i = 0; i < iterations; i++) listener.count.incrementAndGet();
+            for (int i = 0; i < iterations; i++) listener.increment();
         });
         Thread t2 = new Thread(() -> {
-            for (int i = 0; i < iterations; i++) listener.count.incrementAndGet();
+            for (int i = 0; i < iterations; i++) listener.increment();
         });
 
         t1.start();


### PR DESCRIPTION
## Summary

- **SSRF fix**: validate `ECS_CONTAINER_METADATA_URI_V4` URI — reject anything where scheme ≠ `http` or host ≠ `169.254.170.2`
- **RCE fix**: replace SnakeYAML (unsafe `Yaml().load()`) with Jackson `readTree()` for ECS metadata parsing; remove SnakeYAML dependency
- **Input validation**: trim and validate server name against CloudWatch dimension constraints (1–256 printable ASCII) at startup
- **Static field fix**: `dimension` demoted from `static` to instance field — prevents stale value surviving plugin reloads
- **Log sanitization**: AWS error logging changed from `errorMessage()` (may contain ARNs/account IDs) to `errorCode()` only
- **Thread leak fix**: `HttpClient` in `resolveInstanceId()` now uses a custom executor shut down in `finally` — deterministic cleanup on each reload
- **Atomic heap metrics**: switched from three non-atomic `Runtime` calls to `MemoryMXBean.getHeapMemoryUsage()` snapshot
- **Performance**: cache JMX bean references as fields; inject `dimension`/`cloudWatchClient` into runnable constructors; use `List.of()` in `JavaStatisticsRunnable`
- **Encapsulation**: `EventCountListener.count` made `private` with `protected increment()` method; all 15 subclasses and tests updated

## Test plan

- [ ] `mvn test` passes (23 tests)
- [ ] Deploy to EC2 instance and verify metrics appear in CloudWatch under `Server = <instance-id>`
- [ ] Deploy to ECS and verify `Server = <task-id>`
- [ ] Set `SPIGOT_CLOUDWATCH_SERVER=my-server` and verify that name is used
- [ ] Set an invalid server name (>256 chars or non-ASCII) and verify plugin self-disables with a clear log message