### PR TITLE
feat: add EntityCount metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ CloudWatch namespace: `Minecraft`. All values represent the maximum value, count
 - Number of Online Players
 - Maximum Tick Time
 - Ticks per Second
+- Number of Entities (live count across all worlds)
 - Number of Chunks Loaded
 - Number of Chunks Populated
 - Number of Creatures Spawned

--- a/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
+++ b/src/main/java/github/metalshark/cloudwatch/CloudWatch.java
@@ -6,6 +6,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import github.metalshark.cloudwatch.listeners.*;
 import github.metalshark.cloudwatch.runnables.JavaStatisticsRunnable;
 import github.metalshark.cloudwatch.runnables.MinecraftStatisticsRunnable;
+import github.metalshark.cloudwatch.runnables.EntityCountSampler;
 import github.metalshark.cloudwatch.runnables.TickRunnable;
 import lombok.Getter;
 import org.bukkit.Bukkit;
@@ -40,6 +41,9 @@ public class CloudWatch extends JavaPlugin {
 
     @Getter
     private final TickRunnable tickRunnable = new TickRunnable();
+
+    @Getter
+    private final EntityCountSampler entityCountSampler = new EntityCountSampler();
 
     @Getter
     private final static Map<String, EventCountListener> eventCountListeners = new ConcurrentHashMap<>();
@@ -174,6 +178,7 @@ public class CloudWatch extends JavaPlugin {
             new MinecraftStatisticsRunnable(this, dimension, cloudWatchClient), 0, 1, TimeUnit.MINUTES);
 
         Bukkit.getServer().getScheduler().runTaskTimerAsynchronously(this, tickRunnable, 1, 1);
+        Bukkit.getServer().getScheduler().runTaskTimer(this, entityCountSampler, 0, 1200);
     }
 
     @Override

--- a/src/main/java/github/metalshark/cloudwatch/runnables/EntityCountSampler.java
+++ b/src/main/java/github/metalshark/cloudwatch/runnables/EntityCountSampler.java
@@ -1,0 +1,27 @@
+package github.metalshark.cloudwatch.runnables;
+
+import org.bukkit.Bukkit;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Samples total live entity count across all worlds on the main server thread.
+ * Must be scheduled as a sync task so Bukkit world state is safe to read.
+ * The async stats runnable reads the cached value via getEntityCount().
+ */
+public class EntityCountSampler implements Runnable {
+
+    private final AtomicLong entityCount = new AtomicLong(0);
+
+    @Override
+    public void run() {
+        entityCount.set(Bukkit.getWorlds().stream()
+            .mapToLong(w -> w.getEntities().size())
+            .sum());
+    }
+
+    public long getEntityCount() {
+        return entityCount.get();
+    }
+
+}

--- a/src/main/java/github/metalshark/cloudwatch/runnables/MinecraftStatisticsRunnable.java
+++ b/src/main/java/github/metalshark/cloudwatch/runnables/MinecraftStatisticsRunnable.java
@@ -23,13 +23,15 @@ public class MinecraftStatisticsRunnable implements Runnable {
     public void run() {
         final double chunksLoaded = plugin.getChunkLoadListener().getMaxAndReset();
         final double onlinePlayers = plugin.getPlayerJoinListener().getMaxAndReset();
+        final double entityCount = plugin.getEntityCountSampler().getEntityCount();
 
         final TickRunnable tickRunnable = plugin.getTickRunnable();
         final double maxTickTime = tickRunnable.getMaxElapsedMillisAndReset();
         final double ticksPerSecond = tickRunnable.getNumberOfTicksAndReset() / 60.0;
 
         try {
-            final List<MetricDatum> metrics = new ArrayList<>(4 + CloudWatch.getEventCountListeners().size());
+            final List<MetricDatum> metrics = new ArrayList<>(5 + CloudWatch.getEventCountListeners().size());
+            metrics.add(MetricDatum.builder().metricName("EntityCount").unit(StandardUnit.COUNT).value(entityCount).dimensions(dimension).build());
             metrics.add(MetricDatum.builder().metricName("ChunksLoaded").unit(StandardUnit.COUNT).value(chunksLoaded).dimensions(dimension).build());
             metrics.add(MetricDatum.builder().metricName("OnlinePlayers").unit(StandardUnit.COUNT).value(onlinePlayers).dimensions(dimension).build());
             metrics.add(MetricDatum.builder().metricName("MaxTickTime").unit(StandardUnit.MILLISECONDS).value(maxTickTime).dimensions(dimension).build());


### PR DESCRIPTION
## Summary

- Adds `EntityCount` gauge to the `Minecraft` CloudWatch namespace — total live entities across all worlds, sampled once per minute
- Implemented as a sync Bukkit task (`EntityCountSampler`) so world state is read safely on the main thread; the async stats runnable reads the cached `AtomicLong`
- Updated README

## Why EntityCount matters

High entity counts are the #1 cause of TPS drops and weren't previously observable. This metric correlates directly with `MaxTickTime` spikes.